### PR TITLE
Fixed date display on tabs and picker in timetable [Material]

### DIFF
--- a/lib/interface/shared/pages/timetable.dart
+++ b/lib/interface/shared/pages/timetable.dart
@@ -453,7 +453,7 @@ class _TimetablePageState extends VisibilityAwareState<TimetablePage> {
               margin: EdgeInsets.only(
                   top: Share.settings.appSettings.useCupertino ? 2 : 5,
                   bottom: Share.settings.appSettings.useCupertino ? 2 : 5,
-                  right: Share.settings.appSettings.useCupertino ? 0 : 25),
+                  right: Share.settings.appSettings.useCupertino ? 0 : 20),
               child:
                   TextChip(width: 110, text: DateFormat.yMd(Share.settings.appSettings.localeCode).format(selectedDate)))),
       trailing: isWorking

--- a/lib/interface/shared/pages/timetable.dart
+++ b/lib/interface/shared/pages/timetable.dart
@@ -537,7 +537,7 @@ class _TimetablePageState extends VisibilityAwareState<TimetablePage> {
           x,
           DateFormat('EEEEE, d.MM', Share.settings.appSettings.localeCode)
               .format((isBeforeSchoolYear ? DateTime.now().asDate() : Share.session.data.student.mainClass.beginSchoolYear)
-                  .add(Duration(days: x)))
+                  .addDate(days: x))
               .capitalize())),
       segmentController: segmentController,
       pageBuilder: Share.settings.appSettings.useCupertino ? null : timetableBuilder,

--- a/lib/share/extensions.dart
+++ b/lib/share/extensions.dart
@@ -6,6 +6,17 @@ import 'package:oshi/share/resources.dart';
 import 'package:oshi/share/share.dart';
 import 'package:oshi/share/translator.dart';
 
+extension DateTimeAddDate on DateTime {
+  DateTime addDate({int years = 0, int months = 0, int days = 0}) {
+    if (years == 0 && months == 0 && days == 0) return this;
+    return isUtc
+        ? DateTime.utc(year + years, month + months, day + days, hour, minute,
+            second, millisecond, microsecond)
+        : DateTime(year + years, month + months, day + days, hour, minute,
+            second, millisecond, microsecond);
+  }
+}
+
 extension ListExtension<T> on List<T> {
   Iterable<T> intersperse(T element) sync* {
     for (int i = 0; i < length; i++) {


### PR DESCRIPTION
`Duration` was causing time shifts due to daylight saving, making the time off by an hour and messing up the end of the day. This caused days to duplicate and dates to be off. I think it will work OK now